### PR TITLE
Refactor Sort Direction/Sort By and make it work with Pagination

### DIFF
--- a/PMU_DjangoWebApps/PerInd/templates/PerInd.template.webgrid.html
+++ b/PMU_DjangoWebApps/PerInd/templates/PerInd.template.webgrid.html
@@ -79,22 +79,22 @@
         {% if is_paginated %}
             {% if page_obj.has_previous %}
 
-                <a class="btn btn-outline-info" href="?page=1">First</a>
-                <a class="btn btn-outline-info" href="?page={{ page_obj.previous_page_number }}">Previous</a>
+                <a class="btn btn-outline-info" href="?page=1&SortBy={{ sort_by }}&SortDir={{ sort_dir }}">First</a>
+                <a class="btn btn-outline-info" href="?page={{ page_obj.previous_page_number }}&SortBy={{ sort_by }}&SortDir={{ sort_dir }}">Previous</a>
             {% endif %}
 
             {%for num in page_obj.paginator.page_range %}
                 {% if page_obj.number == num %}
-                    <a class=" btn btn-info" href="?page= {{ num }}">{{ num }}</a>
+                    <a class=" btn btn-info" href="?page= {{ num }}&SortBy={{ sort_by }}&SortDir={{ sort_dir }}">{{ num }}</a>
                 {% elif num > page_obj.number|add:'-3' and num < page_obj.number|add:'3' %}
-                    <a class=" btn btn-outline-info" href="?page= {{ num }}">{{ num }}</a>
+                    <a class=" btn btn-outline-info" href="?page= {{ num }}&SortBy={{ sort_by }}&SortDir={{ sort_dir }}">{{ num }}</a>
                 {% endif %}
             {% endfor %}
 
             {% if page_obj.has_next %}
 
-                <a class="btn btn-outline-info" href="?page={{ page_obj.next_page_number }}">Next</a>
-                <a class="btn btn-outline-info" href="?page= {{ page_obj.paginator.num_pages}}">Last</a>
+                <a class="btn btn-outline-info" href="?page={{ page_obj.next_page_number }}&SortBy={{ sort_by }}&SortDir={{ sort_dir }}">Next</a>
+                <a class="btn btn-outline-info" href="?page= {{ page_obj.paginator.num_pages}}&SortBy={{ sort_by }}&SortDir={{ sort_dir }}">Last</a>
 
             {% endif %}
 

--- a/PMU_DjangoWebApps/PerInd/templates/PerInd.template.webgrid.html
+++ b/PMU_DjangoWebApps/PerInd/templates/PerInd.template.webgrid.html
@@ -10,9 +10,21 @@
         <table class="table table-striped table-hover">
             <thead>
                 <tr>
-                    <th data-SortDir="ascInd"><a href="{% if sort_dir == 'descInd' %} ?SortDir=ascInd {% elif sort_dir == 'ascInd' %} ?SortDir=descInd {% else %} ?SortDir=ascInd {% endif %}">Indicator Title</th>
-                    <th data-SortDir="ascYY"><a href="{% if sort_dir == 'descYY' %} ?SortDir=ascYY {% elif sort_dir == 'ascYY' %} ?SortDir=descYY {% else %} ?SortDir=ascYY {% endif %}">Year</th>
-                    <th data-SortDir="ascMM"><a href="{% if sort_dir == 'descMM' %} ?SortDir=ascMM {% elif sort_dir == 'ascMM' %} ?SortDir=descMM {% else %} ?SortDir=ascMM {% endif %}">Month</th>
+                    <th>
+                        <a href="?SortBy=indicator__indicator_title&{% if sort_by == 'indicator__indicator_title' and sort_dir == 'desc' %}SortDir=asc{% elif sort_by == 'indicator__indicator_title' and sort_dir == 'asc' %}SortDir=desc{% else %}SortDir=asc{% endif %}">
+                        Indicator Title
+                        </a>
+                    </th>
+                    <th>
+                        <a href="?SortBy=year_month__yyyy&{% if sort_by == 'year_month__yyyy' and sort_dir == 'desc' %}SortDir=asc{% elif sort_by == 'year_month__yyyy' and sort_dir == 'asc' %}SortDir=desc{% else %}SortDir=asc{% endif %}">
+                        Year
+                        </a>
+                    </th>
+                    <th>
+                        <a href="?SortBy=year_month__mm&{% if sort_by == 'year_month__mm' and sort_dir == 'desc' %}SortDir=asc{% elif sort_by == 'year_month__mm' and sort_dir == 'asc' %}SortDir=desc{% else %}SortDir=asc{% endif %}">
+                        Month
+                        </a>
+                    </th>
                     <th>Indicator Value</th>
                     <th>Updated Date</th>
                     <th>Last Updated By</th>
@@ -63,6 +75,7 @@
             </tbody>
         </table>
         <!-- Paginations-->
+                <!-- @TODO need to add template url for this entire page to link with. -->
         {% if is_paginated %}
             {% if page_obj.has_previous %}
 

--- a/PMU_DjangoWebApps/PerInd/views.py
+++ b/PMU_DjangoWebApps/PerInd/views.py
@@ -153,8 +153,6 @@ class WebGridPageView(generic.ListView):
         if (temp_sort_by is not None and temp_sort_by != ''):
             self.req_sort_by = temp_sort_by
 
-        # print("dir: '{}', by: '{}'".format(self.req_sort_dir, self.req_sort_by))
-
         # Get list authorized Categories of Indicator Data, and log the category_permissions
         user_cat_permissions = get_user_category_permissions(self.request.user)
         if user_cat_permissions["success"] == False:
@@ -178,7 +176,6 @@ class WebGridPageView(generic.ListView):
             return IndicatorData.objects.none()
 
         # @TODO Filter for only searched indicator title
-        # @TODO Sort it asc or desc on sort_by
         try:
             if self.req_sort_dir == "asc":
                 indicator_data_entries = indicator_data_entries.order_by(self.req_sort_by)


### PR DESCRIPTION
Fix bug where Pagination cancels out the sorting of a selected column

For example, currently, if you selected sort by Month Ascending, the page will load and you will be on Page 1. Then if you click on Page 2, the sorting of the Month Ascending is gone, and has gone back to the defaults of sorting by Indicator Title Ascending, but it is on the Page 2 of this Indicator Title Ascending sort context.

What I did was to include the GET parameters that sorts the WebGrid: SortDir, and SortBy, and also the Page in all the Pager links.
Ex.
```
<a class=" btn btn-info" href="?page= {{ num }}&SortBy={{ sort_by }}&SortDir={{ sort_dir }}">{{ num }}</a>
```
which can translate to URL: 
https://127.0.0.1/PerInd/webgrid?page=2&SortBy=indicator__indicator_title&SortDir=desc