### PR TITLE
Dropdown filter

### DIFF
--- a/PMU_DjangoWebApps/PerInd/templates/PerInd.template.webgrid.html
+++ b/PMU_DjangoWebApps/PerInd/templates/PerInd.template.webgrid.html
@@ -1,107 +1,177 @@
 {% extends 'template.base.html' %}
 <!-- Will contain the template for the WebGrid html -->
 {% block content %}
-<div class="container">
-    <div>Permission: {% for each in category_permissions %}{{each}}, {% endfor %}</div>
-    <div class="status_info led_light">Database Status: {% if req_success %}<div class='led_green'></div>{% else %}<div class='led_red'></div>{% endif %}</div>
-    <div class="status_info err_msg">{% if not req_success %} Error: '{{ err_msg }}'<br>Please try reloading the page again!<br>Please contact ykuang@dot.nyc.gov with a screenshot if this error continues. {% else %}{% endif %}</div>
+<style>
+    .dropdown,.content {
+        margin: 2.5px;
+       
+    }
 
-    <div class="table">
-        <table class="table table-striped table-hover">
-            <thead>
-                <tr>
-                    <th>
-                        <a href="?SortBy=indicator__indicator_title&{% if sort_by == 'indicator__indicator_title' and sort_dir == 'asc' %}SortDir=desc{% elif sort_by == 'indicator__indicator_title' and sort_dir == 'desc' %}SortDir=asc{% else %}SortDir=asc{% endif %}">
-                        Indicator Title{% if sort_by == 'indicator__indicator_title' and sort_dir == 'asc' %} <i class="fas fa-caret-up"></i></i>{% elif sort_by == 'indicator__indicator_title' and sort_dir == 'desc' %} <i class="fas fa-caret-down"></i>{% endif %}
-                        </a>
-                    </th>
-                    <th>
-                        <a href="?SortBy=year_month__yyyy&{% if sort_by == 'year_month__yyyy' and sort_dir == 'asc' %}SortDir=desc{% elif sort_by == 'year_month__yyyy' and sort_dir == 'desc' %}SortDir=asc{% else %}SortDir=asc{% endif %}">
-                        Year{% if sort_by == 'year_month__yyyy' and sort_dir == 'asc' %} <i class="fas fa-caret-up"></i></i>{% elif sort_by == 'year_month__yyyy' and sort_dir == 'desc' %} <i class="fas fa-caret-down"></i>{% endif %}
-                        </a>
-                    </th>
-                    <th>
-                        <a href="?SortBy=year_month__mm&{% if sort_by == 'year_month__mm' and sort_dir == 'asc' %}SortDir=desc{% elif sort_by == 'year_month__mm' and sort_dir == 'desc' %}SortDir=asc{% else %}SortDir=asc{% endif %}">
-                        Month{% if sort_by == 'year_month__mm' and sort_dir == 'asc' %} <i class="fas fa-caret-up"></i></i>{% elif sort_by == 'year_month__mm' and sort_dir == 'desc' %} <i class="fas fa-caret-down"></i>{% endif %}
-                        </a>
-                    </th>
-                    <th>Indicator Value</th>
-                    <th>Updated Date</th>
-                    <th>Last Updated By</th>
-                    <th>Category</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for entry in indicator_data_entries %}
-                <tr>
-                    <td data-id="{{ entry.record_id }}" data-table="IndicatorData" data-column="Indicator">{{ entry.indicator }}</td>
-                    <td data-id="{{ entry.record_id }}" data-table="Year_Month" data-column="YYYY">{{ entry.year_month.yyyy }}</td>
-                    <!-- <td data-id="{{ entry.record_id }}" data-table="Year_Month" data-column="MM">{{ entry.year_month.mm }}</td> -->
-                    <td data-id="{{ entry.record_id }}" data-table="Year_Month" data-column="MM">
-                    {% if entry.year_month.mm == 1 %}
-                        Jan
-                    {% elif entry.year_month.mm == 2 %}
-                        Feb
-                    {% elif entry.year_month.mm == 3 %}
-                        Mar
-                    {% elif entry.year_month.mm == 4 %}
-                        Apr
-                    {% elif entry.year_month.mm == 5 %}
-                        May
-                    {% elif entry.year_month.mm == 6 %}
-                        Jun
-                    {% elif entry.year_month.mm == 7 %}
-                        Jul
-                    {% elif entry.year_month.mm == 8 %}
-                        Aug
-                    {% elif entry.year_month.mm == 9 %}
-                        Sep
-                    {% elif entry.year_month.mm == 10 %}
-                        Oct
-                    {% elif entry.year_month.mm == 11 %}
-                        Nov
-                    {% elif entry.year_month.mm == 12 %}
-                        Dec
+   
+</style>
+    <div class="container">
+        <div>Permission: {% for each in category_permissions %}{{each}}, {% endfor %}</div>
+        <div class="status_info led_light">Database Status: {% if req_success %}<div class='led_green'></div>{% else %}<div class='led_red'></div>{% endif %}</div>
+        <div class="status_info err_msg">{% if not req_success %} Error: '{{ err_msg }}'<br>Please try reloading the page again!<br>Please contact ykuang@dot.nyc.gov with a screenshot if this error continues. {% else %}{% endif %}</div>
+        <!--Dropdown-->
+        <div class="container">
+            <div class="dropdown">
+                <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                     Title
+                </button>
+                <div class="dropdown-menu" aria-labelledby="dropdownMenuButton1">
+                    {% for each in uniq_titles %}
+                    <a data-unique_title="ind" class="dropdown-item" href="#">{{ each.indicator__indicator_title }}</a>
+                    {% endfor %}
+                </div>
+            </div>
+            <div class="dropdown">
+                <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton2" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    Year
+                </button>
+                <div class="dropdown-menu" aria-labelledby="dropdownMenuButton2">
+                    {% for each in uniq_years %}
+                    <a data-unique_title="ind" class="dropdown-item" href="#">{{ each.year_month__yyyy}}</a>
+                    {% endfor %}
+                </div>
+            </div>
+            <div class="dropdown">
+                <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton3" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    Month
+                </button>
+                <div class="dropdown-menu" aria-labelledby="dropdownMenuButton3">
+                    {% for each in uniq_months %}
+                    {% if each.year_month__mm == 1 %}
+                    <a data-unique_title="ind" class="dropdown-item" href="#">Jan</a>
+                    {% elif each.year_month__mm == 2 %}
+                    <a data-unique_title="ind" class="dropdown-item" href="#">Feb</a>
+                    {% elif each.year_month__mm == 3 %}
+                    <a data-unique_title="ind" class="dropdown-item" href="#">Mar</a>
+                    {% elif each.year_month__mm == 4 %}
+                    <a data-unique_title="ind" class="dropdown-item" href="#">Apr</a>
+                    {% elif each.year_month__mm == 5 %}
+                    <a data-unique_title="ind" class="dropdown-item" href="#">May</a>
+                    {% elif each.year_month__mm == 6 %}
+                    <a data-unique_title="ind" class="dropdown-item" href="#">Jun</a>
+                    {% elif each.year_month__mm == 7 %}
+                    <a data-unique_title="ind" class="dropdown-item" href="#">Jul</a>
+                    {% elif each.year_month__mm == 8 %}
+                    <a data-unique_title="ind" class="dropdown-item" href="#">Aug</a>
+                    {% elif each.year_month__mm == 9 %}
+                    <a data-unique_title="ind" class="dropdown-item" href="#">Sep</a>
+                    {% elif each.year_month__mm == 10 %}
+                    <a data-unique_title="ind" class="dropdown-item" href="#">Oct</a>
+                    {% elif each.year_month__mm == 11 %}
+                    <a data-unique_title="ind" class="dropdown-item" href="#">Nov</a>
+                    {% elif each.year_month__mm == 12 %}
+                    <a data-unique_title="ind" class="dropdown-item" href="#">Dec</a>
                     {% else %}
-                        Unrecognized Month
+                    Unrecognized Month
                     {% endif %}
-                    </td>
-                    <td class="editable" data-id="{{ entry.record_id }}" data-table="IndicatorData" data-column="val">{{ entry.val }}</td>
-                    <td data-id="{{ entry.record_id }}" data-table="IndicatorData" data-column="UpdatedDate">{{ entry.updated_date }}</td>
-                    <td data-id="{{ entry.record_id }}" data-table="IndicatorData" data-column="UpdateUser">{{ entry.update_user }}</td>
-                    <td data-id="{{ entry.record_id }}" data-table="Category" data-column="Category_Name">{{ entry.indicator.category.category_name }}</td>
-                </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-        <!-- Paginations-->
-                <!-- @TODO need to add template url for this entire page to link with. -->
-        {% if is_paginated %}
+
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+        <!--End Dropdown-->
+        <div class="table">
+            <table class="table table-striped table-hover">
+                <thead>
+                    <tr>
+                        <th>
+                            <a href="?SortBy=indicator__indicator_title&{% if sort_by == 'indicator__indicator_title' and sort_dir == 'asc' %}SortDir=desc{% elif sort_by == 'indicator__indicator_title' and sort_dir == 'desc' %}SortDir=asc{% else %}SortDir=asc{% endif %}">
+                                Indicator Title{% if sort_by == 'indicator__indicator_title' and sort_dir == 'asc' %} <i class="fas fa-caret-up"></i></i>{% elif sort_by == 'indicator__indicator_title' and sort_dir == 'desc' %} <i class="fas fa-caret-down"></i>{% endif %}
+                            </a>
+                        </th>
+                     
+                        <th>
+           
+                            <a href="?SortBy=year_month__yyyy&{% if sort_by == 'year_month__yyyy' and sort_dir == 'asc' %}SortDir=desc{% elif sort_by == 'year_month__yyyy' and sort_dir == 'desc' %}SortDir=asc{% else %}SortDir=asc{% endif %}">
+                                Year{% if sort_by == 'year_month__yyyy' and sort_dir == 'asc' %} <i class="fas fa-caret-up"></i></i>{% elif sort_by == 'year_month__yyyy' and sort_dir == 'desc' %} <i class="fas fa-caret-down"></i>{% endif %}
+                            </a>
+                        </th>
+                        <th>
+                            <a href="?SortBy=year_month__mm&{% if sort_by == 'year_month__mm' and sort_dir == 'asc' %}SortDir=desc{% elif sort_by == 'year_month__mm' and sort_dir == 'desc' %}SortDir=asc{% else %}SortDir=asc{% endif %}">
+                                Month{% if sort_by == 'year_month__mm' and sort_dir == 'asc' %} <i class="fas fa-caret-up"></i></i>{% elif sort_by == 'year_month__mm' and sort_dir == 'desc' %} <i class="fas fa-caret-down"></i>{% endif %}
+                            </a>
+                        </th>
+                        <th>Indicator Value</th>
+                        <th>Updated Date</th>
+                        <th>Last Updated By</th>
+                        <th>Category</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for entry in indicator_data_entries %}
+                    <tr>
+                        <td data-id="{{ entry.record_id }}" data-table="IndicatorData" data-column="Indicator">{{ entry.indicator }}</td>
+                        <td data-id="{{ entry.record_id }}" data-table="Year_Month" data-column="YYYY">{{ entry.year_month.yyyy }}</td>
+                        <!-- <td data-id="{{ entry.record_id }}" data-table="Year_Month" data-column="MM">{{ entry.year_month.mm }}</td> -->
+                        <td data-id="{{ entry.record_id }}" data-table="Year_Month" data-column="MM">
+                            {% if entry.year_month.mm == 1 %}
+                            Jan
+                            {% elif entry.year_month.mm == 2 %}
+                            Feb
+                            {% elif entry.year_month.mm == 3 %}
+                            Mar
+                            {% elif entry.year_month.mm == 4 %}
+                            Apr
+                            {% elif entry.year_month.mm == 5 %}
+                            May
+                            {% elif entry.year_month.mm == 6 %}
+                            Jun
+                            {% elif entry.year_month.mm == 7 %}
+                            Jul
+                            {% elif entry.year_month.mm == 8 %}
+                            Aug
+                            {% elif entry.year_month.mm == 9 %}
+                            Sep
+                            {% elif entry.year_month.mm == 10 %}
+                            Oct
+                            {% elif entry.year_month.mm == 11 %}
+                            Nov
+                            {% elif entry.year_month.mm == 12 %}
+                            Dec
+                            {% else %}
+                            Unrecognized Month
+                            {% endif %}
+                        </td>
+                        <td class="editable" data-id="{{ entry.record_id }}" data-table="IndicatorData" data-column="val">{{ entry.val }}</td>
+                        <td data-id="{{ entry.record_id }}" data-table="IndicatorData" data-column="UpdatedDate">{{ entry.updated_date }}</td>
+                        <td data-id="{{ entry.record_id }}" data-table="IndicatorData" data-column="UpdateUser">{{ entry.update_user }}</td>
+                        <td data-id="{{ entry.record_id }}" data-table="Category" data-column="Category_Name">{{ entry.indicator.category.category_name }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+            <!-- Paginations-->
+            <!-- @TODO need to add template url for this entire page to link with. -->
+            {% if is_paginated %}
             {% if page_obj.has_previous %}
 
-                <a class="btn btn-outline-info" href="?page=1&SortBy={{ sort_by }}&SortDir={{ sort_dir }}">First</a>
-                <a class="btn btn-outline-info" href="?page={{ page_obj.previous_page_number }}&SortBy={{ sort_by }}&SortDir={{ sort_dir }}">Previous</a>
+            <a class="btn btn-outline-info" href="?page=1&SortBy={{ sort_by }}&SortDir={{ sort_dir }}">First</a>
+            <a class="btn btn-outline-info" href="?page={{ page_obj.previous_page_number }}&SortBy={{ sort_by }}&SortDir={{ sort_dir }}">Previous</a>
             {% endif %}
 
             {%for num in page_obj.paginator.page_range %}
-                {% if page_obj.number == num %}
-                    <a class=" btn btn-info" href="?page= {{ num }}&SortBy={{ sort_by }}&SortDir={{ sort_dir }}">{{ num }}</a>
-                {% elif num > page_obj.number|add:'-3' and num < page_obj.number|add:'3' %}
-                    <a class=" btn btn-outline-info" href="?page= {{ num }}&SortBy={{ sort_by }}&SortDir={{ sort_dir }}">{{ num }}</a>
-                {% endif %}
+            {% if page_obj.number == num %}
+            <a class=" btn btn-info" href="?page= {{ num }}&SortBy={{ sort_by }}&SortDir={{ sort_dir }}">{{ num }}</a>
+            {% elif num > page_obj.number|add:'-3' and num < page_obj.number|add:'3' %}
+            <a class=" btn btn-outline-info" href="?page= {{ num }}&SortBy={{ sort_by }}&SortDir={{ sort_dir }}">{{ num }}</a>
+            {% endif %}
             {% endfor %}
 
             {% if page_obj.has_next %}
 
-                <a class="btn btn-outline-info" href="?page={{ page_obj.next_page_number }}&SortBy={{ sort_by }}&SortDir={{ sort_dir }}">Next</a>
-                <a class="btn btn-outline-info" href="?page= {{ page_obj.paginator.num_pages}}&SortBy={{ sort_by }}&SortDir={{ sort_dir }}">Last</a>
+            <a class="btn btn-outline-info" href="?page={{ page_obj.next_page_number }}&SortBy={{ sort_by }}&SortDir={{ sort_dir }}">Next</a>
+            <a class="btn btn-outline-info" href="?page= {{ page_obj.paginator.num_pages}}&SortBy={{ sort_by }}&SortDir={{ sort_dir }}">Last</a>
 
             {% endif %}
 
-        {% endif %}
-        <!--end pagination-->
+            {% endif %}
+            <!--end pagination-->
+        </div>
     </div>
-</div>
 {% endblock content %}
 
 {% block custom_js %}

--- a/PMU_DjangoWebApps/PerInd/templates/PerInd.template.webgrid.html
+++ b/PMU_DjangoWebApps/PerInd/templates/PerInd.template.webgrid.html
@@ -156,22 +156,22 @@
             {% if is_paginated %}
             {% if page_obj.has_previous %}
 
-            <a class="btn btn-outline-info" href="?page=1&SortBy={{ sort_by }}&SortDir={{ sort_dir }}">First</a>
-            <a class="btn btn-outline-info" href="?page={{ page_obj.previous_page_number }}&SortBy={{ sort_by }}&SortDir={{ sort_dir }}">Previous</a>
+            <a class="btn btn-outline-info" href="?page=1&SortBy={{ sort_by }}&SortDir={{ sort_dir }}&title_list= {{ title_list }}">First</a>
+            <a class="btn btn-outline-info" href="?page={{ page_obj.previous_page_number }}&SortBy={{ sort_by }}&SortDir={{ sort_dir }}&title_list= {{ title_list }}">Previous</a>
             {% endif %}
 
             {%for num in page_obj.paginator.page_range %}
             {% if page_obj.number == num %}
-            <a class=" btn btn-info" href="?page= {{ num }}&SortBy={{ sort_by }}&SortDir={{ sort_dir }}">{{ num }}</a>
+            <a class=" btn btn-info" href="?page= {{ num }}&SortBy={{ sort_by }}&SortDir={{ sort_dir }}&title_list= {{ title_list }}">{{ num }}</a>
             {% elif num > page_obj.number|add:'-3' and num < page_obj.number|add:'3' %}
-            <a class=" btn btn-outline-info" href="?page= {{ num }}&SortBy={{ sort_by }}&SortDir={{ sort_dir }}">{{ num }}</a>
+            <a class=" btn btn-outline-info" href="?page= {{ num }}&SortBy={{ sort_by }}&SortDir={{ sort_dir }}&title_list= {{ title_list }}">{{ num }}</a>
             {% endif %}
             {% endfor %}
 
             {% if page_obj.has_next %}
 
-            <a class="btn btn-outline-info" href="?page={{ page_obj.next_page_number }}&SortBy={{ sort_by }}&SortDir={{ sort_dir }}">Next</a>
-            <a class="btn btn-outline-info" href="?page= {{ page_obj.paginator.num_pages}}&SortBy={{ sort_by }}&SortDir={{ sort_dir }}">Last</a>
+            <a class="btn btn-outline-info" href="?page={{ page_obj.next_page_number }}&SortBy={{ sort_by }}&SortDir={{ sort_dir }}&title_list= {{ title_list }}">Next</a>
+            <a class="btn btn-outline-info" href="?page= {{ page_obj.paginator.num_pages}}&SortBy={{ sort_by }}&SortDir={{ sort_dir }}&title_list= {{ title_list }}">Last</a>
 
             {% endif %}
 

--- a/PMU_DjangoWebApps/PerInd/templates/PerInd.template.webgrid.html
+++ b/PMU_DjangoWebApps/PerInd/templates/PerInd.template.webgrid.html
@@ -21,7 +21,7 @@
                 </button>
                 <div class="dropdown-menu" aria-labelledby="dropdownMenuButton1">
                     {% for each in uniq_titles %}
-                    <a data-unique_title="ind" class="dropdown-item" href="#">{{ each.indicator__indicator_title }}</a>
+                    <a data-unique_title="ind" class="dropdown-item" href="#"><input type="checkbox"> {{ each.indicator__indicator_title }}</input></a>
                     {% endfor %}
                 </div>
             </div>

--- a/PMU_DjangoWebApps/PerInd/templates/PerInd.template.webgrid.html
+++ b/PMU_DjangoWebApps/PerInd/templates/PerInd.template.webgrid.html
@@ -21,7 +21,7 @@
                 </button>
                 <div class="dropdown-menu" aria-labelledby="dropdownMenuButton1">
                     {% for each in uniq_titles %}
-                    <a data-unique_title="ind" class="dropdown-item" href="#"><input type="checkbox"> {{ each.indicator__indicator_title }}</input></a>
+                    <a data-unique_title="ind" class="dropdown-item" href="#"><input type="checkbox"/> {{ each.indicator__indicator_title }}</a>
                     {% endfor %}
                     <button type="button" class="btn btn-info">Filter</button>
                 </div>
@@ -32,10 +32,10 @@
                 </button>
                 <div class="dropdown-menu" aria-labelledby="dropdownMenuButton2">
                     {% for each in uniq_years %}
-                    <a data-unique_title="ind" class="dropdown-item" href="#">{{ each.year_month__yyyy}}</a>
-                    
-                    {% endfor %}
+                    <a data-unique_title="ind" class="dropdown-item" href="#"><input type="checkbox" /> {{ each.year_month__yyyy}}</a>
 
+                    {% endfor %}
+                    <button type="button" class="btn btn-info">Filter</button>
                 </div>
             </div>
             <div class="dropdown">
@@ -44,35 +44,37 @@
                 </button>
                 <div class="dropdown-menu" aria-labelledby="dropdownMenuButton3">
                     {% for each in uniq_months %}
+
                     {% if each.year_month__mm == 1 %}
-                    <a data-unique_title="ind" class="dropdown-item" href="#">Jan</a>
+                    <a data-unique_title="ind" class="dropdown-item" href="#"><input type="checkbox" /> Jan</a>
                     {% elif each.year_month__mm == 2 %}
-                    <a data-unique_title="ind" class="dropdown-item" href="#">Feb</a>
+                    <a data-unique_title="ind" class="dropdown-item" href="#"><input type="checkbox" /> Feb</a>
                     {% elif each.year_month__mm == 3 %}
-                    <a data-unique_title="ind" class="dropdown-item" href="#">Mar</a>
+                    <a data-unique_title="ind" class="dropdown-item" href="#"><input type="checkbox" /> Mar</a>
                     {% elif each.year_month__mm == 4 %}
-                    <a data-unique_title="ind" class="dropdown-item" href="#">Apr</a>
+                    <a data-unique_title="ind" class="dropdown-item" href="#"><input type="checkbox" /> Apr</a>
                     {% elif each.year_month__mm == 5 %}
-                    <a data-unique_title="ind" class="dropdown-item" href="#">May</a>
+                    <a data-unique_title="ind" class="dropdown-item" href="#"><input type="checkbox" /> May</a>
                     {% elif each.year_month__mm == 6 %}
-                    <a data-unique_title="ind" class="dropdown-item" href="#">Jun</a>
+                    <a data-unique_title="ind" class="dropdown-item" href="#"><input type="checkbox" /> Jun</a>
                     {% elif each.year_month__mm == 7 %}
-                    <a data-unique_title="ind" class="dropdown-item" href="#">Jul</a>
+                    <a data-unique_title="ind" class="dropdown-item" href="#"><input type="checkbox" /> Jul</a>
                     {% elif each.year_month__mm == 8 %}
-                    <a data-unique_title="ind" class="dropdown-item" href="#">Aug</a>
+                    <a data-unique_title="ind" class="dropdown-item" href="#"><input type="checkbox" /> Aug</a>
                     {% elif each.year_month__mm == 9 %}
-                    <a data-unique_title="ind" class="dropdown-item" href="#">Sep</a>
+                    <a data-unique_title="ind" class="dropdown-item" href="#"><input type="checkbox" /> Sep</a>
                     {% elif each.year_month__mm == 10 %}
-                    <a data-unique_title="ind" class="dropdown-item" href="#">Oct</a>
+                    <a data-unique_title="ind" class="dropdown-item" href="#"><input type="checkbox" /> Oct</a>
                     {% elif each.year_month__mm == 11 %}
-                    <a data-unique_title="ind" class="dropdown-item" href="#">Nov</a>
+                    <a data-unique_title="ind" class="dropdown-item" href="#"><input type="checkbox" /> Nov</a>
                     {% elif each.year_month__mm == 12 %}
-                    <a data-unique_title="ind" class="dropdown-item" href="#">Dec</a>
+                    <a data-unique_title="ind" class="dropdown-item" href="#"><input type="checkbox" /> Dec</a>
                     {% else %}
                     Unrecognized Month
                     {% endif %}
 
                     {% endfor %}
+                    <button type="button" class="btn btn-info">Filter</button>
                 </div>
             </div>
         </div>

--- a/PMU_DjangoWebApps/PerInd/templates/PerInd.template.webgrid.html
+++ b/PMU_DjangoWebApps/PerInd/templates/PerInd.template.webgrid.html
@@ -19,12 +19,14 @@
                 <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                      Title
                 </button>
-                <div class="dropdown-menu" aria-labelledby="dropdownMenuButton1">
-                    {% for each in uniq_titles %}
-                    <a data-unique_title="ind" class="dropdown-item" href="#"><input type="checkbox"/> {{ each.indicator__indicator_title }}</a>
-                    {% endfor %}
-                    <button type="button" class="btn btn-info">Filter</button>
-                </div>
+                <form>
+                    <div class="dropdown-menu" aria-labelledby="dropdownMenuButton1">
+                        {% for each in uniq_titles %}
+                        <a data-unique_title="ind" class="dropdown-item"><input type="checkbox" name="title_list" value="{{ each.indicator__indicator_title }}"/> {{ each.indicator__indicator_title }}</a>
+                        {% endfor %}
+                        <button type="submit" class="btn btn-info">Filter</button>
+                    </div>
+                </form>
             </div>
             <div class="dropdown">
                 <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton2" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/PMU_DjangoWebApps/PerInd/templates/PerInd.template.webgrid.html
+++ b/PMU_DjangoWebApps/PerInd/templates/PerInd.template.webgrid.html
@@ -90,16 +90,17 @@
             <thead>
                 <tr>
                     <th>
-                        <a href="?SortBy=indicator__indicator_title&{% if sort_by == 'indicator__indicator_title' and sort_dir == 'asc' %}SortDir=desc{% elif sort_by == 'indicator__indicator_title' and sort_dir == 'desc' %}SortDir=asc{% else %}SortDir=asc{% endif %}">
+                        <a href="?{{ IndicatorAnchorParam }}">
+                            <!--<a href="?SortBy=indicator__indicator_title&{% if sort_by == 'indicator__indicator_title' and sort_dir == 'asc' %}SortDir=desc{% elif sort_by == 'indicator__indicator_title' and sort_dir == 'desc' %}SortDir=asc{% else %}SortDir=asc{% endif %}">-->
                             Indicator Title{% if sort_by == 'indicator__indicator_title' and sort_dir == 'asc' %} <i class="fas fa-caret-up"></i></i>{% elif sort_by == 'indicator__indicator_title' and sort_dir == 'desc' %} <i class="fas fa-caret-down"></i>{% endif %}
                         </a>
                     </th>
 
                     <th>
-
-                        <a href="?SortBy=year_month__yyyy&{% if sort_by == 'year_month__yyyy' and sort_dir == 'asc' %}SortDir=desc{% elif sort_by == 'year_month__yyyy' and sort_dir == 'desc' %}SortDir=asc{% else %}SortDir=asc{% endif %}">
-                            Year{% if sort_by == 'year_month__yyyy' and sort_dir == 'asc' %} <i class="fas fa-caret-up"></i></i>{% elif sort_by == 'year_month__yyyy' and sort_dir == 'desc' %} <i class="fas fa-caret-down"></i>{% endif %}
-                        </a>
+                        <a href="?{{YYYYAnchorParam}}">
+                            <!--<a href="?SortBy=year_month__yyyy&{% if sort_by == 'year_month__yyyy' and sort_dir == 'asc' %}SortDir=desc{% elif sort_by == 'year_month__yyyy' and sort_dir == 'desc' %}SortDir=asc{% else %}SortDir=asc{% endif %}">-->
+                                Year{% if sort_by == 'year_month__yyyy' and sort_dir == 'asc' %} <i class="fas fa-caret-up"></i></i>{% elif sort_by == 'year_month__yyyy' and sort_dir == 'desc' %} <i class="fas fa-caret-down"></i>{% endif %}
+                            </a>
                     </th>
                     <th>
                         <a href="?SortBy=year_month__mm&{% if sort_by == 'year_month__mm' and sort_dir == 'asc' %}SortDir=desc{% elif sort_by == 'year_month__mm' and sort_dir == 'desc' %}SortDir=asc{% else %}SortDir=asc{% endif %}">
@@ -162,12 +163,12 @@
         {% if page_obj.has_previous %}
         {% if filterStatus == True %}
         {% for each in title_list %}
-        <a class="btn btn-outline-info" href="?page=1{{ urlParam }}">First</a>
-        <a class="btn btn-outline-info" href="?page={{ page_obj.previous_page_number }}{{ urlParam }}">Previous</a>
+        <a class="btn btn-outline-info" href="?page=1&{{ urlParam }}">First</a>
+        <a class="btn btn-outline-info" href="?page={{ page_obj.previous_page_number }}&{{ urlParam }}">Previous</a>
         {% endfor %}
         {% elif filterStatus == False %}
         <a class="btn btn-outline-info" href="?page=1{{ urlParam }}">First</a>
-        <a class="btn btn-outline-info" href="?page={{ page_obj.previous_page_number }}{{ urlParam }}">Previous</a>
+        <a class="btn btn-outline-info" href="?page={{ page_obj.previous_page_number }}&{{ urlParam }}">Previous</a>
         {% endif %}
         {% endif %}
         {% endif %}
@@ -175,16 +176,16 @@
         {% if filterStatus == True %}
         {% for each in title_list %}
         {% if page_obj.number == num %}
-        <a class=" btn btn-info" href="?page={{ num }}{{ urlParam }}">{{ num }}</a>
+        <a class=" btn btn-info" href="?page={{ num }}&{{ urlParam }}">{{ num }}</a>
         {% elif num > page_obj.number|add:'-3' and num < page_obj.number|add:'3' %}
-        <a class=" btn btn-outline-info" href="?page={{ num }}{{ urlParam }}">{{ num }}</a>
+        <a class=" btn btn-outline-info" href="?page={{ num }}&{{ urlParam }}">{{ num }}</a>
         {% endif %}
         {% endfor %}
         {% elif filterStatus == False %}
         {% if page_obj.number == num %}
-        <a class=" btn btn-info" href="?page={{ num }}{{ urlParam }}">{{ num }}</a>
+        <a class=" btn btn-info" href="?page={{ num }}&{{ urlParam }}">{{ num }}</a>
         {% elif num > page_obj.number|add:'-3' and num < page_obj.number|add:'3' %}
-        <a class=" btn btn-outline-info" href="?page={{ num }}{{ urlParam }}">{{ num }}</a>
+        <a class=" btn btn-outline-info" href="?page={{ num }}&{{ urlParam }}">{{ num }}</a>
         {% endif %}
         {% endif %}
         {% endfor %}
@@ -193,12 +194,12 @@
         {% if page_obj.has_next %}
         {% if filterStatus == True %}
         {% for each in title_list %}
-        <a class="btn btn-outline-info" href="?page={{ page_obj.next_page_number }}{{ urlParam }}">Next</a>
-        <a class="btn btn-outline-info" href="?page={{ page_obj.paginator.num_pages}}{{ urlParam }}">Last</a>
+        <a class="btn btn-outline-info" href="?page={{ page_obj.next_page_number }}&{{ urlParam }}">Next</a>
+        <a class="btn btn-outline-info" href="?page={{ page_obj.paginator.num_pages}}&{{ urlParam }}">Last</a>
         {% endfor %}
         {% elif filterStatus == False %}
-        <a class="btn btn-outline-info" href="?page={{ page_obj.next_page_number }}{{ urlParam }}">Next</a>
-        <a class="btn btn-outline-info" href="?page={{ page_obj.paginator.num_pages}}{{ urlParam }}">Last</a>
+        <a class="btn btn-outline-info" href="?page={{ page_obj.next_page_number }}&{{ urlParam }}">Next</a>
+        <a class="btn btn-outline-info" href="?page={{ page_obj.paginator.num_pages}}&{{ urlParam }}">Last</a>
         {% endif %}
         {% endif %}
         <!--end pagination-->

--- a/PMU_DjangoWebApps/PerInd/templates/PerInd.template.webgrid.html
+++ b/PMU_DjangoWebApps/PerInd/templates/PerInd.template.webgrid.html
@@ -89,20 +89,17 @@
             <thead>
                 <tr>
                     <th>
-                        <!-- <a href="?SortBy=indicator__indicator_title&{% if sort_by == 'indicator__indicator_title' and sort_dir == 'asc' %}SortDir=desc{% elif sort_by == 'indicator__indicator_title' and sort_dir == 'desc' %}SortDir=asc{% else %}SortDir=asc{% endif %}"> -->
                         <a href="?{{ title_sort_anchor_GET_param }}">
                             Indicator Title{% if sort_by == 'indicator__indicator_title' and sort_dir == 'asc' %} <i class="fas fa-caret-up"></i></i>{% elif sort_by == 'indicator__indicator_title' and sort_dir == 'desc' %} <i class="fas fa-caret-down"></i>{% endif %}
                         </a>
                     </th>
 
                     <th>
-                        <!-- <a href="?SortBy=year_month__yyyy&{% if sort_by == 'year_month__yyyy' and sort_dir == 'asc' %}SortDir=desc{% elif sort_by == 'year_month__yyyy' and sort_dir == 'desc' %}SortDir=asc{% else %}SortDir=asc{% endif %}"> -->
                         <a href="?{{ yyyy_sort_anchor_GET_param }}">
                             Year{% if sort_by == 'year_month__yyyy' and sort_dir == 'asc' %} <i class="fas fa-caret-up"></i></i>{% elif sort_by == 'year_month__yyyy' and sort_dir == 'desc' %} <i class="fas fa-caret-down"></i>{% endif %}
                         </a>
                     </th>
                     <th>
-                        <!-- <a href="?SortBy=year_month__mm&{% if sort_by == 'year_month__mm' and sort_dir == 'asc' %}SortDir=desc{% elif sort_by == 'year_month__mm' and sort_dir == 'desc' %}SortDir=asc{% else %}SortDir=asc{% endif %}"> -->
                         <a href="?{{ mm_sort_anchor_GET_param }}">
                             Month{% if sort_by == 'year_month__mm' and sort_dir == 'asc' %} <i class="fas fa-caret-up"></i></i>{% elif sort_by == 'year_month__mm' and sort_dir == 'desc' %} <i class="fas fa-caret-down"></i>{% endif %}
                         </a>

--- a/PMU_DjangoWebApps/PerInd/templates/PerInd.template.webgrid.html
+++ b/PMU_DjangoWebApps/PerInd/templates/PerInd.template.webgrid.html
@@ -23,6 +23,7 @@
                     {% for each in uniq_titles %}
                     <a data-unique_title="ind" class="dropdown-item" href="#"><input type="checkbox"> {{ each.indicator__indicator_title }}</input></a>
                     {% endfor %}
+                    <button type="button" class="btn btn-info">Filter</button>
                 </div>
             </div>
             <div class="dropdown">
@@ -32,7 +33,9 @@
                 <div class="dropdown-menu" aria-labelledby="dropdownMenuButton2">
                     {% for each in uniq_years %}
                     <a data-unique_title="ind" class="dropdown-item" href="#">{{ each.year_month__yyyy}}</a>
+                    
                     {% endfor %}
+
                 </div>
             </div>
             <div class="dropdown">

--- a/PMU_DjangoWebApps/PerInd/templates/PerInd.template.webgrid.html
+++ b/PMU_DjangoWebApps/PerInd/templates/PerInd.template.webgrid.html
@@ -7,14 +7,13 @@
        
     }
 
-   
 </style>
 <div class="container">
     <div>Permission: {% for each in category_permissions %}{{each}}, {% endfor %}</div>
     <div class="status_info led_light">Database Status: {% if req_success %}<div class='led_green'></div>{% else %}<div class='led_red'></div>{% endif %}</div>
     <div class="status_info err_msg">{% if not req_success %} Error: '{{ err_msg }}'<br>Please try reloading the page again!<br>Please contact ykuang@dot.nyc.gov with a screenshot if this error continues. {% else %}{% endif %}</div>
     <!--Dropdown-->
-    <div>URLPARAM: {{ urlParam }}</div>
+    <div>CURRENT CONTEXT PARAM: {{ ctx_filter_sort_param }}</div>
     <div class="container">
         <div class="dropdown">
             <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -23,7 +22,7 @@
             <form>
                 <div class="dropdown-menu" aria-labelledby="dropdownMenuButton1">
                     {% for each in uniq_titles %}
-                    <a data-unique_title="ind" class="dropdown-item"><input type="checkbox" name="title_list" value="{{ each.indicator__indicator_title }}" /> {{ each.indicator__indicator_title }}</a>
+                    <a data-unique_title="ind" class="dropdown-item"><input type="checkbox" name="TitleListFilter" value="{{ each.indicator__indicator_title }}" /> {{ each.indicator__indicator_title }}</a>
                     {% endfor %}
                     <button type="submit" class="btn btn-info">Filter</button>
                 </div>
@@ -36,7 +35,7 @@
             <form>
                 <div class="dropdown-menu" aria-labelledby="dropdownMenuButton2">
                     {% for each in uniq_years %}
-                    <a data-unique_title="yr" class="dropdown-item"><input type="checkbox" name="yr_list" value="{{ each.year_month__yyyy }}" /> {{ each.year_month__yyyy}}</a>
+                    <a data-unique_title="yr" class="dropdown-item"><input type="checkbox" name="YYYYListFilter" value="{{ each.year_month__yyyy }}" /> {{ each.year_month__yyyy}}</a>
                     {% endfor %}
                     <button type="submit" class="btn btn-info">Filter</button>
                 </div>
@@ -51,29 +50,29 @@
                     {% for each in uniq_months %}
 
                     {% if each.year_month__mm == 1 %}
-                    <a data-unique_title="ind" class="dropdown-item"><input type="checkbox" name="mn_list" value="{{ each.year_month__mm }}"/> Jan</a>
+                    <a data-unique_title="ind" class="dropdown-item"><input type="checkbox" name="MMListFilter" value="{{ each.year_month__mm }}"/> Jan</a>
                     {% elif each.year_month__mm == 2 %}
-                    <a data-unique_title="ind" class="dropdown-item" ><input type="checkbox" name="mn_list" value="{{ each.year_month__mm }}"/> Feb</a>
+                    <a data-unique_title="ind" class="dropdown-item" ><input type="checkbox" name="MMListFilter" value="{{ each.year_month__mm }}"/> Feb</a>
                     {% elif each.year_month__mm == 3 %}
-                    <a data-unique_title="ind" class="dropdown-item"><input type="checkbox" name="mn_list" value="{{ each.year_month__mm }}"/> Mar</a>
+                    <a data-unique_title="ind" class="dropdown-item"><input type="checkbox" name="MMListFilter" value="{{ each.year_month__mm }}"/> Mar</a>
                     {% elif each.year_month__mm == 4 %}
-                    <a data-unique_title="ind" class="dropdown-item" ><input type="checkbox" name="mn_list" value="{{ each.year_month__mm }}"/> Apr</a>
+                    <a data-unique_title="ind" class="dropdown-item" ><input type="checkbox" name="MMListFilter" value="{{ each.year_month__mm }}"/> Apr</a>
                     {% elif each.year_month__mm == 5 %}
-                    <a data-unique_title="ind" class="dropdown-item" ><input type="checkbox" name="mn_list" value="{{ each.year_month__mm }}"/> May</a>
+                    <a data-unique_title="ind" class="dropdown-item" ><input type="checkbox" name="MMListFilter" value="{{ each.year_month__mm }}"/> May</a>
                     {% elif each.year_month__mm == 6 %}
-                    <a data-unique_title="ind" class="dropdown-item" ><input type="checkbox" name="mn_list" value="{{ each.year_month__mm }}"/> Jun</a>
+                    <a data-unique_title="ind" class="dropdown-item" ><input type="checkbox" name="MMListFilter" value="{{ each.year_month__mm }}"/> Jun</a>
                     {% elif each.year_month__mm == 7 %}
-                    <a data-unique_title="ind" class="dropdown-item" ><input type="checkbox" name="mn_list" value="{{ each.year_month__mm }}"/> Jul</a>
+                    <a data-unique_title="ind" class="dropdown-item" ><input type="checkbox" name="MMListFilter" value="{{ each.year_month__mm }}"/> Jul</a>
                     {% elif each.year_month__mm == 8 %}
-                    <a data-unique_title="ind" class="dropdown-item" ><input type="checkbox" name="mn_list" value="{{ each.year_month__mm }}"/> Aug</a>
+                    <a data-unique_title="ind" class="dropdown-item" ><input type="checkbox" name="MMListFilter" value="{{ each.year_month__mm }}"/> Aug</a>
                     {% elif each.year_month__mm == 9 %}
-                    <a data-unique_title="ind" class="dropdown-item"><input type="checkbox" name="mn_list" value="{{ each.year_month__mm }}"/> Sep</a>
+                    <a data-unique_title="ind" class="dropdown-item"><input type="checkbox" name="MMListFilter" value="{{ each.year_month__mm }}"/> Sep</a>
                     {% elif each.year_month__mm == 10 %}
-                    <a data-unique_title="ind" class="dropdown-item" ><input type="checkbox" name="mn_list" value="{{ each.year_month__mm }}"/> Oct</a>
+                    <a data-unique_title="ind" class="dropdown-item" ><input type="checkbox" name="MMListFilter" value="{{ each.year_month__mm }}"/> Oct</a>
                     {% elif each.year_month__mm == 11 %}
-                    <a data-unique_title="ind" class="dropdown-item" ><input type="checkbox" name="mn_list" value="{{ each.year_month__mm }}"/> Nov</a>
+                    <a data-unique_title="ind" class="dropdown-item" ><input type="checkbox" name="MMListFilter" value="{{ each.year_month__mm }}"/> Nov</a>
                     {% elif each.year_month__mm == 12 %}
-                    <a data-unique_title="ind" class="dropdown-item"><input type="checkbox" name="mn_list" value="{{ each.year_month__mm }}"/> Dec</a>
+                    <a data-unique_title="ind" class="dropdown-item"><input type="checkbox" name="MMListFilter" value="{{ each.year_month__mm }}"/> Dec</a>
                     {% else %}
                     Unrecognized Month
                     {% endif %}
@@ -90,20 +89,21 @@
             <thead>
                 <tr>
                     <th>
-                        <a href="?{{ IndicatorAnchorParam }}">
-                            <!--<a href="?SortBy=indicator__indicator_title&{% if sort_by == 'indicator__indicator_title' and sort_dir == 'asc' %}SortDir=desc{% elif sort_by == 'indicator__indicator_title' and sort_dir == 'desc' %}SortDir=asc{% else %}SortDir=asc{% endif %}">-->
+                        <!-- <a href="?SortBy=indicator__indicator_title&{% if sort_by == 'indicator__indicator_title' and sort_dir == 'asc' %}SortDir=desc{% elif sort_by == 'indicator__indicator_title' and sort_dir == 'desc' %}SortDir=asc{% else %}SortDir=asc{% endif %}"> -->
+                        <a href="?{{ title_sort_anchor_GET_param }}">
                             Indicator Title{% if sort_by == 'indicator__indicator_title' and sort_dir == 'asc' %} <i class="fas fa-caret-up"></i></i>{% elif sort_by == 'indicator__indicator_title' and sort_dir == 'desc' %} <i class="fas fa-caret-down"></i>{% endif %}
                         </a>
                     </th>
 
                     <th>
-                        <a href="?{{YYYYAnchorParam}}">
-                            <!--<a href="?SortBy=year_month__yyyy&{% if sort_by == 'year_month__yyyy' and sort_dir == 'asc' %}SortDir=desc{% elif sort_by == 'year_month__yyyy' and sort_dir == 'desc' %}SortDir=asc{% else %}SortDir=asc{% endif %}">-->
-                                Year{% if sort_by == 'year_month__yyyy' and sort_dir == 'asc' %} <i class="fas fa-caret-up"></i></i>{% elif sort_by == 'year_month__yyyy' and sort_dir == 'desc' %} <i class="fas fa-caret-down"></i>{% endif %}
-                            </a>
+                        <!-- <a href="?SortBy=year_month__yyyy&{% if sort_by == 'year_month__yyyy' and sort_dir == 'asc' %}SortDir=desc{% elif sort_by == 'year_month__yyyy' and sort_dir == 'desc' %}SortDir=asc{% else %}SortDir=asc{% endif %}"> -->
+                        <a href="?{{ yyyy_sort_anchor_GET_param }}">
+                            Year{% if sort_by == 'year_month__yyyy' and sort_dir == 'asc' %} <i class="fas fa-caret-up"></i></i>{% elif sort_by == 'year_month__yyyy' and sort_dir == 'desc' %} <i class="fas fa-caret-down"></i>{% endif %}
+                        </a>
                     </th>
                     <th>
-                        <a href="?SortBy=year_month__mm&{% if sort_by == 'year_month__mm' and sort_dir == 'asc' %}SortDir=desc{% elif sort_by == 'year_month__mm' and sort_dir == 'desc' %}SortDir=asc{% else %}SortDir=asc{% endif %}">
+                        <!-- <a href="?SortBy=year_month__mm&{% if sort_by == 'year_month__mm' and sort_dir == 'asc' %}SortDir=desc{% elif sort_by == 'year_month__mm' and sort_dir == 'desc' %}SortDir=asc{% else %}SortDir=asc{% endif %}"> -->
+                        <a href="?{{ mm_sort_anchor_GET_param }}">
                             Month{% if sort_by == 'year_month__mm' and sort_dir == 'asc' %} <i class="fas fa-caret-up"></i></i>{% elif sort_by == 'year_month__mm' and sort_dir == 'desc' %} <i class="fas fa-caret-down"></i>{% endif %}
                         </a>
                     </th>
@@ -160,47 +160,24 @@
         <!-- Paginations-->
         <!-- @TODO need to add template url for this entire page to link with. -->
         {% if is_paginated %}
-        {% if page_obj.has_previous %}
-        {% if filterStatus == True %}
-        {% for each in title_list %}
-        <a class="btn btn-outline-info" href="?page=1&{{ urlParam }}">First</a>
-        <a class="btn btn-outline-info" href="?page={{ page_obj.previous_page_number }}&{{ urlParam }}">Previous</a>
-        {% endfor %}
-        {% elif filterStatus == False %}
-        <a class="btn btn-outline-info" href="?page=1{{ urlParam }}">First</a>
-        <a class="btn btn-outline-info" href="?page={{ page_obj.previous_page_number }}&{{ urlParam }}">Previous</a>
-        {% endif %}
-        {% endif %}
-        {% endif %}
-        {%for num in page_obj.paginator.page_range %}
-        {% if filterStatus == True %}
-        {% for each in title_list %}
-        {% if page_obj.number == num %}
-        <a class=" btn btn-info" href="?page={{ num }}&{{ urlParam }}">{{ num }}</a>
-        {% elif num > page_obj.number|add:'-3' and num < page_obj.number|add:'3' %}
-        <a class=" btn btn-outline-info" href="?page={{ num }}&{{ urlParam }}">{{ num }}</a>
-        {% endif %}
-        {% endfor %}
-        {% elif filterStatus == False %}
-        {% if page_obj.number == num %}
-        <a class=" btn btn-info" href="?page={{ num }}&{{ urlParam }}">{{ num }}</a>
-        {% elif num > page_obj.number|add:'-3' and num < page_obj.number|add:'3' %}
-        <a class=" btn btn-outline-info" href="?page={{ num }}&{{ urlParam }}">{{ num }}</a>
-        {% endif %}
-        {% endif %}
-        {% endfor %}
+            {% if page_obj.has_previous %}
+                <a class="btn btn-outline-info" href="?page=1&{{ ctx_filter_sort_param }}">First</a>
+                <a class="btn btn-outline-info" href="?page={{ page_obj.previous_page_number }}&{{ ctx_filter_sort_param }}">Previous</a>
+            {% endif %}
 
+            {%for num in page_obj.paginator.page_range %}
+                {% if page_obj.number == num %}
+                    <a class=" btn btn-info" href="?page= {{ num }}&{{ ctx_filter_sort_param }}">{{ num }}</a>
+                {% elif num > page_obj.number|add:'-3' and num < page_obj.number|add:'3' %}
+                    <a class=" btn btn-outline-info" href="?page= {{ num }}&{{ ctx_filter_sort_param }}">{{ num }}</a>
+                {% endif %}
+            {% endfor %}
 
-        {% if page_obj.has_next %}
-        {% if filterStatus == True %}
-        {% for each in title_list %}
-        <a class="btn btn-outline-info" href="?page={{ page_obj.next_page_number }}&{{ urlParam }}">Next</a>
-        <a class="btn btn-outline-info" href="?page={{ page_obj.paginator.num_pages}}&{{ urlParam }}">Last</a>
-        {% endfor %}
-        {% elif filterStatus == False %}
-        <a class="btn btn-outline-info" href="?page={{ page_obj.next_page_number }}&{{ urlParam }}">Next</a>
-        <a class="btn btn-outline-info" href="?page={{ page_obj.paginator.num_pages}}&{{ urlParam }}">Last</a>
-        {% endif %}
+            {% if page_obj.has_next %}
+
+                <a class="btn btn-outline-info" href="?page={{ page_obj.next_page_number }}&{{ ctx_filter_sort_param }}">Next</a>
+                <a class="btn btn-outline-info" href="?page= {{ page_obj.paginator.num_pages}}&{{ ctx_filter_sort_param }}">Last</a>
+            {% endif %}
         {% endif %}
         <!--end pagination-->
     </div>
@@ -208,8 +185,6 @@
 {% endblock content %}
 
 {% block custom_js %}
-
-
 <script>
     $(document).ready(function(){
         $(document).on("dblclick", ".editable", function(){

--- a/PMU_DjangoWebApps/PerInd/templates/PerInd.template.webgrid.html
+++ b/PMU_DjangoWebApps/PerInd/templates/PerInd.template.webgrid.html
@@ -9,176 +9,201 @@
 
    
 </style>
+<div class="container">
+    <div>Permission: {% for each in category_permissions %}{{each}}, {% endfor %}</div>
+    <div class="status_info led_light">Database Status: {% if req_success %}<div class='led_green'></div>{% else %}<div class='led_red'></div>{% endif %}</div>
+    <div class="status_info err_msg">{% if not req_success %} Error: '{{ err_msg }}'<br>Please try reloading the page again!<br>Please contact ykuang@dot.nyc.gov with a screenshot if this error continues. {% else %}{% endif %}</div>
+    <!--Dropdown-->
+    <div>URLPARAM: {{ urlParam }}</div>
     <div class="container">
-        <div>Permission: {% for each in category_permissions %}{{each}}, {% endfor %}</div>
-        <div class="status_info led_light">Database Status: {% if req_success %}<div class='led_green'></div>{% else %}<div class='led_red'></div>{% endif %}</div>
-        <div class="status_info err_msg">{% if not req_success %} Error: '{{ err_msg }}'<br>Please try reloading the page again!<br>Please contact ykuang@dot.nyc.gov with a screenshot if this error continues. {% else %}{% endif %}</div>
-        <!--Dropdown-->
-        <div class="container">
-            <div class="dropdown">
-                <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                     Title
-                </button>
-                <form>
-                    <div class="dropdown-menu" aria-labelledby="dropdownMenuButton1">
-                        {% for each in uniq_titles %}
-                        <a data-unique_title="ind" class="dropdown-item"><input type="checkbox" name="title_list" value="{{ each.indicator__indicator_title }}"/> {{ each.indicator__indicator_title }}</a>
-                        {% endfor %}
-                        <button type="submit" class="btn btn-info">Filter</button>
-                    </div>
-                </form>
-            </div>
-            <div class="dropdown">
-                <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton2" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                    Year
-                </button>
+        <div class="dropdown">
+            <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                Title
+            </button>
+            <form>
+                <div class="dropdown-menu" aria-labelledby="dropdownMenuButton1">
+                    {% for each in uniq_titles %}
+                    <a data-unique_title="ind" class="dropdown-item"><input type="checkbox" name="title_list" value="{{ each.indicator__indicator_title }}" /> {{ each.indicator__indicator_title }}</a>
+                    {% endfor %}
+                    <button type="submit" class="btn btn-info">Filter</button>
+                </div>
+            </form>
+        </div>
+        <div class="dropdown">
+            <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton2" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                Year
+            </button>
+            <form>
                 <div class="dropdown-menu" aria-labelledby="dropdownMenuButton2">
                     {% for each in uniq_years %}
-                    <a data-unique_title="ind" class="dropdown-item" href="#"><input type="checkbox" /> {{ each.year_month__yyyy}}</a>
-
+                    <a data-unique_title="yr" class="dropdown-item"><input type="checkbox" name="yr_list" value="{{ each.year_month__yyyy }}" /> {{ each.year_month__yyyy}}</a>
                     {% endfor %}
-                    <button type="button" class="btn btn-info">Filter</button>
+                    <button type="submit" class="btn btn-info">Filter</button>
                 </div>
-            </div>
-            <div class="dropdown">
-                <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton3" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                    Month
-                </button>
+            </form>
+        </div>
+        <div class="dropdown">
+            <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton3" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                Month
+            </button>
+            <form>
                 <div class="dropdown-menu" aria-labelledby="dropdownMenuButton3">
                     {% for each in uniq_months %}
 
                     {% if each.year_month__mm == 1 %}
-                    <a data-unique_title="ind" class="dropdown-item" href="#"><input type="checkbox" /> Jan</a>
+                    <a data-unique_title="ind" class="dropdown-item"><input type="checkbox" name="mn_list" value="{{ each.year_month__mm }}"/> Jan</a>
                     {% elif each.year_month__mm == 2 %}
-                    <a data-unique_title="ind" class="dropdown-item" href="#"><input type="checkbox" /> Feb</a>
+                    <a data-unique_title="ind" class="dropdown-item" ><input type="checkbox" name="mn_list" value="{{ each.year_month__mm }}"/> Feb</a>
                     {% elif each.year_month__mm == 3 %}
-                    <a data-unique_title="ind" class="dropdown-item" href="#"><input type="checkbox" /> Mar</a>
+                    <a data-unique_title="ind" class="dropdown-item"><input type="checkbox" name="mn_list" value="{{ each.year_month__mm }}"/> Mar</a>
                     {% elif each.year_month__mm == 4 %}
-                    <a data-unique_title="ind" class="dropdown-item" href="#"><input type="checkbox" /> Apr</a>
+                    <a data-unique_title="ind" class="dropdown-item" ><input type="checkbox" name="mn_list" value="{{ each.year_month__mm }}"/> Apr</a>
                     {% elif each.year_month__mm == 5 %}
-                    <a data-unique_title="ind" class="dropdown-item" href="#"><input type="checkbox" /> May</a>
+                    <a data-unique_title="ind" class="dropdown-item" ><input type="checkbox" name="mn_list" value="{{ each.year_month__mm }}"/> May</a>
                     {% elif each.year_month__mm == 6 %}
-                    <a data-unique_title="ind" class="dropdown-item" href="#"><input type="checkbox" /> Jun</a>
+                    <a data-unique_title="ind" class="dropdown-item" ><input type="checkbox" name="mn_list" value="{{ each.year_month__mm }}"/> Jun</a>
                     {% elif each.year_month__mm == 7 %}
-                    <a data-unique_title="ind" class="dropdown-item" href="#"><input type="checkbox" /> Jul</a>
+                    <a data-unique_title="ind" class="dropdown-item" ><input type="checkbox" name="mn_list" value="{{ each.year_month__mm }}"/> Jul</a>
                     {% elif each.year_month__mm == 8 %}
-                    <a data-unique_title="ind" class="dropdown-item" href="#"><input type="checkbox" /> Aug</a>
+                    <a data-unique_title="ind" class="dropdown-item" ><input type="checkbox" name="mn_list" value="{{ each.year_month__mm }}"/> Aug</a>
                     {% elif each.year_month__mm == 9 %}
-                    <a data-unique_title="ind" class="dropdown-item" href="#"><input type="checkbox" /> Sep</a>
+                    <a data-unique_title="ind" class="dropdown-item"><input type="checkbox" name="mn_list" value="{{ each.year_month__mm }}"/> Sep</a>
                     {% elif each.year_month__mm == 10 %}
-                    <a data-unique_title="ind" class="dropdown-item" href="#"><input type="checkbox" /> Oct</a>
+                    <a data-unique_title="ind" class="dropdown-item" ><input type="checkbox" name="mn_list" value="{{ each.year_month__mm }}"/> Oct</a>
                     {% elif each.year_month__mm == 11 %}
-                    <a data-unique_title="ind" class="dropdown-item" href="#"><input type="checkbox" /> Nov</a>
+                    <a data-unique_title="ind" class="dropdown-item" ><input type="checkbox" name="mn_list" value="{{ each.year_month__mm }}"/> Nov</a>
                     {% elif each.year_month__mm == 12 %}
-                    <a data-unique_title="ind" class="dropdown-item" href="#"><input type="checkbox" /> Dec</a>
+                    <a data-unique_title="ind" class="dropdown-item"><input type="checkbox" name="mn_list" value="{{ each.year_month__mm }}"/> Dec</a>
                     {% else %}
                     Unrecognized Month
                     {% endif %}
 
                     {% endfor %}
-                    <button type="button" class="btn btn-info">Filter</button>
+                    <button type="submit" class="btn btn-info">Filter</button>
                 </div>
-            </div>
-        </div>
-        <!--End Dropdown-->
-        <div class="table">
-            <table class="table table-striped table-hover">
-                <thead>
-                    <tr>
-                        <th>
-                            <a href="?SortBy=indicator__indicator_title&{% if sort_by == 'indicator__indicator_title' and sort_dir == 'asc' %}SortDir=desc{% elif sort_by == 'indicator__indicator_title' and sort_dir == 'desc' %}SortDir=asc{% else %}SortDir=asc{% endif %}">
-                                Indicator Title{% if sort_by == 'indicator__indicator_title' and sort_dir == 'asc' %} <i class="fas fa-caret-up"></i></i>{% elif sort_by == 'indicator__indicator_title' and sort_dir == 'desc' %} <i class="fas fa-caret-down"></i>{% endif %}
-                            </a>
-                        </th>
-                     
-                        <th>
-           
-                            <a href="?SortBy=year_month__yyyy&{% if sort_by == 'year_month__yyyy' and sort_dir == 'asc' %}SortDir=desc{% elif sort_by == 'year_month__yyyy' and sort_dir == 'desc' %}SortDir=asc{% else %}SortDir=asc{% endif %}">
-                                Year{% if sort_by == 'year_month__yyyy' and sort_dir == 'asc' %} <i class="fas fa-caret-up"></i></i>{% elif sort_by == 'year_month__yyyy' and sort_dir == 'desc' %} <i class="fas fa-caret-down"></i>{% endif %}
-                            </a>
-                        </th>
-                        <th>
-                            <a href="?SortBy=year_month__mm&{% if sort_by == 'year_month__mm' and sort_dir == 'asc' %}SortDir=desc{% elif sort_by == 'year_month__mm' and sort_dir == 'desc' %}SortDir=asc{% else %}SortDir=asc{% endif %}">
-                                Month{% if sort_by == 'year_month__mm' and sort_dir == 'asc' %} <i class="fas fa-caret-up"></i></i>{% elif sort_by == 'year_month__mm' and sort_dir == 'desc' %} <i class="fas fa-caret-down"></i>{% endif %}
-                            </a>
-                        </th>
-                        <th>Indicator Value</th>
-                        <th>Updated Date</th>
-                        <th>Last Updated By</th>
-                        <th>Category</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for entry in indicator_data_entries %}
-                    <tr>
-                        <td data-id="{{ entry.record_id }}" data-table="IndicatorData" data-column="Indicator">{{ entry.indicator }}</td>
-                        <td data-id="{{ entry.record_id }}" data-table="Year_Month" data-column="YYYY">{{ entry.year_month.yyyy }}</td>
-                        <!-- <td data-id="{{ entry.record_id }}" data-table="Year_Month" data-column="MM">{{ entry.year_month.mm }}</td> -->
-                        <td data-id="{{ entry.record_id }}" data-table="Year_Month" data-column="MM">
-                            {% if entry.year_month.mm == 1 %}
-                            Jan
-                            {% elif entry.year_month.mm == 2 %}
-                            Feb
-                            {% elif entry.year_month.mm == 3 %}
-                            Mar
-                            {% elif entry.year_month.mm == 4 %}
-                            Apr
-                            {% elif entry.year_month.mm == 5 %}
-                            May
-                            {% elif entry.year_month.mm == 6 %}
-                            Jun
-                            {% elif entry.year_month.mm == 7 %}
-                            Jul
-                            {% elif entry.year_month.mm == 8 %}
-                            Aug
-                            {% elif entry.year_month.mm == 9 %}
-                            Sep
-                            {% elif entry.year_month.mm == 10 %}
-                            Oct
-                            {% elif entry.year_month.mm == 11 %}
-                            Nov
-                            {% elif entry.year_month.mm == 12 %}
-                            Dec
-                            {% else %}
-                            Unrecognized Month
-                            {% endif %}
-                        </td>
-                        <td class="editable" data-id="{{ entry.record_id }}" data-table="IndicatorData" data-column="val">{{ entry.val }}</td>
-                        <td data-id="{{ entry.record_id }}" data-table="IndicatorData" data-column="UpdatedDate">{{ entry.updated_date }}</td>
-                        <td data-id="{{ entry.record_id }}" data-table="IndicatorData" data-column="UpdateUser">{{ entry.update_user }}</td>
-                        <td data-id="{{ entry.record_id }}" data-table="Category" data-column="Category_Name">{{ entry.indicator.category.category_name }}</td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-            <!-- Paginations-->
-            <!-- @TODO need to add template url for this entire page to link with. -->
-            {% if is_paginated %}
-            {% if page_obj.has_previous %}
-
-            <a class="btn btn-outline-info" href="?page=1&SortBy={{ sort_by }}&SortDir={{ sort_dir }}&title_list= {{ title_list }}">First</a>
-            <a class="btn btn-outline-info" href="?page={{ page_obj.previous_page_number }}&SortBy={{ sort_by }}&SortDir={{ sort_dir }}&title_list= {{ title_list }}">Previous</a>
-            {% endif %}
-
-            {%for num in page_obj.paginator.page_range %}
-            {% if page_obj.number == num %}
-            <a class=" btn btn-info" href="?page= {{ num }}&SortBy={{ sort_by }}&SortDir={{ sort_dir }}&title_list= {{ title_list }}">{{ num }}</a>
-            {% elif num > page_obj.number|add:'-3' and num < page_obj.number|add:'3' %}
-            <a class=" btn btn-outline-info" href="?page= {{ num }}&SortBy={{ sort_by }}&SortDir={{ sort_dir }}&title_list= {{ title_list }}">{{ num }}</a>
-            {% endif %}
-            {% endfor %}
-
-            {% if page_obj.has_next %}
-
-            <a class="btn btn-outline-info" href="?page={{ page_obj.next_page_number }}&SortBy={{ sort_by }}&SortDir={{ sort_dir }}&title_list= {{ title_list }}">Next</a>
-            <a class="btn btn-outline-info" href="?page= {{ page_obj.paginator.num_pages}}&SortBy={{ sort_by }}&SortDir={{ sort_dir }}&title_list= {{ title_list }}">Last</a>
-
-            {% endif %}
-
-            {% endif %}
-            <!--end pagination-->
+            </form>
         </div>
     </div>
+    <!--End Dropdown-->
+    <div class="table">
+        <table class="table table-striped table-hover">
+            <thead>
+                <tr>
+                    <th>
+                        <a href="?SortBy=indicator__indicator_title&{% if sort_by == 'indicator__indicator_title' and sort_dir == 'asc' %}SortDir=desc{% elif sort_by == 'indicator__indicator_title' and sort_dir == 'desc' %}SortDir=asc{% else %}SortDir=asc{% endif %}">
+                            Indicator Title{% if sort_by == 'indicator__indicator_title' and sort_dir == 'asc' %} <i class="fas fa-caret-up"></i></i>{% elif sort_by == 'indicator__indicator_title' and sort_dir == 'desc' %} <i class="fas fa-caret-down"></i>{% endif %}
+                        </a>
+                    </th>
+
+                    <th>
+
+                        <a href="?SortBy=year_month__yyyy&{% if sort_by == 'year_month__yyyy' and sort_dir == 'asc' %}SortDir=desc{% elif sort_by == 'year_month__yyyy' and sort_dir == 'desc' %}SortDir=asc{% else %}SortDir=asc{% endif %}">
+                            Year{% if sort_by == 'year_month__yyyy' and sort_dir == 'asc' %} <i class="fas fa-caret-up"></i></i>{% elif sort_by == 'year_month__yyyy' and sort_dir == 'desc' %} <i class="fas fa-caret-down"></i>{% endif %}
+                        </a>
+                    </th>
+                    <th>
+                        <a href="?SortBy=year_month__mm&{% if sort_by == 'year_month__mm' and sort_dir == 'asc' %}SortDir=desc{% elif sort_by == 'year_month__mm' and sort_dir == 'desc' %}SortDir=asc{% else %}SortDir=asc{% endif %}">
+                            Month{% if sort_by == 'year_month__mm' and sort_dir == 'asc' %} <i class="fas fa-caret-up"></i></i>{% elif sort_by == 'year_month__mm' and sort_dir == 'desc' %} <i class="fas fa-caret-down"></i>{% endif %}
+                        </a>
+                    </th>
+                    <th>Indicator Value</th>
+                    <th>Updated Date</th>
+                    <th>Last Updated By</th>
+                    <th>Category</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for entry in indicator_data_entries %}
+                <tr>
+                    <td data-id="{{ entry.record_id }}" data-table="IndicatorData" data-column="Indicator">{{ entry.indicator }}</td>
+                    <td data-id="{{ entry.record_id }}" data-table="Year_Month" data-column="YYYY">{{ entry.year_month.yyyy }}</td>
+
+                    <!-- <td data-id="{{ entry.record_id }}" data-table="Year_Month" data-column="MM">{{ entry.year_month.mm }}</td> -->
+                    <td data-id="{{ entry.record_id }}" data-table="Year_Month" data-column="MM">
+                        {% if entry.year_month.mm == 1 %}
+                        Jan
+                        {% elif entry.year_month.mm == 2 %}
+                        Feb
+                        {% elif entry.year_month.mm == 3 %}
+                        Mar
+                        {% elif entry.year_month.mm == 4 %}
+                        Apr
+                        {% elif entry.year_month.mm == 5 %}
+                        May
+                        {% elif entry.year_month.mm == 6 %}
+                        Jun
+                        {% elif entry.year_month.mm == 7 %}
+                        Jul
+                        {% elif entry.year_month.mm == 8 %}
+                        Aug
+                        {% elif entry.year_month.mm == 9 %}
+                        Sep
+                        {% elif entry.year_month.mm == 10 %}
+                        Oct
+                        {% elif entry.year_month.mm == 11 %}
+                        Nov
+                        {% elif entry.year_month.mm == 12 %}
+                        Dec
+                        {% else %}
+                        Unrecognized Month
+                        {% endif %}
+                    </td>
+                    <td class="editable" data-id="{{ entry.record_id }}" data-table="IndicatorData" data-column="val">{{ entry.val }}</td>
+                    <td data-id="{{ entry.record_id }}" data-table="IndicatorData" data-column="UpdatedDate">{{ entry.updated_date }}</td>
+                    <td data-id="{{ entry.record_id }}" data-table="IndicatorData" data-column="UpdateUser">{{ entry.update_user }}</td>
+                    <td data-id="{{ entry.record_id }}" data-table="Category" data-column="Category_Name">{{ entry.indicator.category.category_name }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        <!-- Paginations-->
+        <!-- @TODO need to add template url for this entire page to link with. -->
+        {% if is_paginated %}
+        {% if page_obj.has_previous %}
+        {% if filterStatus == True %}
+        {% for each in title_list %}
+        <a class="btn btn-outline-info" href="?page=1{{ urlParam }}">First</a>
+        <a class="btn btn-outline-info" href="?page={{ page_obj.previous_page_number }}{{ urlParam }}">Previous</a>
+        {% endfor %}
+        {% elif filterStatus == False %}
+        <a class="btn btn-outline-info" href="?page=1{{ urlParam }}">First</a>
+        <a class="btn btn-outline-info" href="?page={{ page_obj.previous_page_number }}{{ urlParam }}">Previous</a>
+        {% endif %}
+        {% endif %}
+        {% endif %}
+        {%for num in page_obj.paginator.page_range %}
+        {% if filterStatus == True %}
+        {% for each in title_list %}
+        {% if page_obj.number == num %}
+        <a class=" btn btn-info" href="?page={{ num }}{{ urlParam }}">{{ num }}</a>
+        {% elif num > page_obj.number|add:'-3' and num < page_obj.number|add:'3' %}
+        <a class=" btn btn-outline-info" href="?page={{ num }}{{ urlParam }}">{{ num }}</a>
+        {% endif %}
+        {% endfor %}
+        {% elif filterStatus == False %}
+        {% if page_obj.number == num %}
+        <a class=" btn btn-info" href="?page={{ num }}{{ urlParam }}">{{ num }}</a>
+        {% elif num > page_obj.number|add:'-3' and num < page_obj.number|add:'3' %}
+        <a class=" btn btn-outline-info" href="?page={{ num }}{{ urlParam }}">{{ num }}</a>
+        {% endif %}
+        {% endif %}
+        {% endfor %}
+
+
+        {% if page_obj.has_next %}
+        {% if filterStatus == True %}
+        {% for each in title_list %}
+        <a class="btn btn-outline-info" href="?page={{ page_obj.next_page_number }}{{ urlParam }}">Next</a>
+        <a class="btn btn-outline-info" href="?page={{ page_obj.paginator.num_pages}}{{ urlParam }}">Last</a>
+        {% endfor %}
+        {% elif filterStatus == False %}
+        <a class="btn btn-outline-info" href="?page={{ page_obj.next_page_number }}{{ urlParam }}">Next</a>
+        <a class="btn btn-outline-info" href="?page={{ page_obj.paginator.num_pages}}{{ urlParam }}">Last</a>
+        {% endif %}
+        {% endif %}
+        <!--end pagination-->
+    </div>
+</div>
 {% endblock content %}
 
 {% block custom_js %}

--- a/PMU_DjangoWebApps/PerInd/views.py
+++ b/PMU_DjangoWebApps/PerInd/views.py
@@ -147,8 +147,11 @@ class WebGridPageView(generic.ListView):
     years=""
     months=""
     
+    title_list = []
   
     def get_queryset(self):
+        
+
         # Collect GET url parameter info
         temp_sort_dir = self.request.GET.get('SortDir')
         if (temp_sort_dir is not None and temp_sort_dir != '') and (temp_sort_dir == 'asc' or temp_sort_dir == 'desc'):
@@ -186,6 +189,18 @@ class WebGridPageView(generic.ListView):
             return IndicatorData.objects.none()
 
         # @TODO Filter for only searched indicator title
+        #if our list is not empty which means a filter form was filled out
+        title_list = self.request.GET.getlist('title_list')
+        if len(title_list) >= 1:
+            try:
+            #filter the queryset for each title in the list:
+                for i in title_list:
+                    indicator_data_entries = indicator_data_entries.filter(indicator__indicator_title=i)
+            except Exception as e:
+                self.req_success = False
+                self.err_msg = "Exception: WebGridPageView(): get_queryset(): title_list: {}".format(e)
+                print(self.err_msg)
+                return IndicatorData.objects.none()
 
         try:
             if self.req_sort_dir == "asc":
@@ -213,6 +228,7 @@ class WebGridPageView(generic.ListView):
             context = super().get_context_data(**kwargs)
 
             # Add my own variables to the context for the front end to shows
+            context["title_list"] = self.title_list
             context["uniq_titles"] = self.titles
             context["uniq_years"] = self.years
             context["uniq_months"] = self.months
@@ -224,6 +240,7 @@ class WebGridPageView(generic.ListView):
             return context
         except Exception as e:
             self.err_msg = "Exception: get_context_data(): {}".format(e)
+            context["title_list"] = self.title_list
             context["uniq_years"] = self.years
             context["uniq_months"] = self.months
             context["uniq_titles"] = self.titles

--- a/PMU_DjangoWebApps/PerInd/views.py
+++ b/PMU_DjangoWebApps/PerInd/views.py
@@ -189,18 +189,9 @@ class WebGridPageView(generic.ListView):
             return IndicatorData.objects.none()
 
         # @TODO Filter for only searched indicator title
-        #if our list is not empty which means a filter form was filled out
-        title_list = self.request.GET.getlist('title_list')
-        if len(title_list) >= 1:
-            try:
-            #filter the queryset for each title in the list:
-                for i in title_list:
-                    indicator_data_entries = indicator_data_entries.filter(indicator__indicator_title=i)
-            except Exception as e:
-                self.req_success = False
-                self.err_msg = "Exception: WebGridPageView(): get_queryset(): title_list: {}".format(e)
-                print(self.err_msg)
-                return IndicatorData.objects.none()
+       
+       
+            
 
         try:
             if self.req_sort_dir == "asc":
@@ -217,6 +208,19 @@ class WebGridPageView(generic.ListView):
             self.err_msg = "Exception: WebGridPageView(): get_queryset(): {}".format(e)
             print(self.err_msg)
             return IndicatorData.objects.none()
+
+         #if our list is not empty which means a filter form was filled out
+        title_list = self.request.GET.getlist('title_list')
+        if len(title_list) >= 1:
+            try:
+            #filter the queryset for each title in the list:
+                for i in title_list:
+                    indicator_data_entries = indicator_data_entries.filter(indicator__indicator_title=i)
+            except Exception as e:
+                self.req_success = False
+                self.err_msg = "Exception: WebGridPageView(): get_queryset(): title_list: {}".format(e)
+                print(self.err_msg)
+                return IndicatorData.objects.none()
 
         self.req_success = True
         return indicator_data_entries
@@ -240,12 +244,13 @@ class WebGridPageView(generic.ListView):
             return context
         except Exception as e:
             self.err_msg = "Exception: get_context_data(): {}".format(e)
-            context["title_list"] = self.title_list
+            
             context["uniq_years"] = self.years
             context["uniq_months"] = self.months
             context["uniq_titles"] = self.titles
             context["sort_dir"] = self.req_sort_dir
             context["sort_by"] = self.req_sort_by
+            context["title_list"] = self.title_list
             context["req_success"] = False
             context["err_msg"] = self.err_msg
             context["category_permissions"] = self.category_permissions

--- a/PMU_DjangoWebApps/PerInd/views.py
+++ b/PMU_DjangoWebApps/PerInd/views.py
@@ -140,6 +140,7 @@ class WebGridPageView(generic.ListView):
     req_success = False
     category_permissions = []
     err_msg = ""
+
     req_sort_dir =  "asc"
     req_sort_by = "indicator__indicator_title"
     
@@ -152,60 +153,84 @@ class WebGridPageView(generic.ListView):
     mn_list = []
     filterStatus = False
 
+    IndicatorAnchorParam = ""
+    YYYYAnchorParam=""
+    MMAnchorParam=""
+    
     urlParam = ""
     
+    tempTile =""
+    tempYear = ""
+    tempMonth = ""
     def get_queryset(self):
-        
-        title_list = self.request.GET.get('title_list')
-        yr_list = self.request.GET.getlist('yr_list')
-        mn_list = self.request.GET.getlist('yr_list')
-
+    
+       
         tempTitle = self.request.GET.getlist('title_list')
         tempYear = self.request.GET.getlist('yr_list')
         tempMonth = self.request.GET.getlist('mn_list')
-        tempSortBy = self.request.GET.getlist('SortBy')
-        tempSortDir = self.request.GET.getlist('SortDir')
-        tempPage = self.request.GET.getlist('page')
+        tempSortBy = self.request.GET.get('SortBy')
+        tempSortDir = self.request.GET.get('SortDir')
+        
         temp=""
         filt = "&title_list="
         temp2=""
         filt2 = "&yr_list="
         temp3=""
         filt3 = "&mn_list="
-        #if (tempSortBy is not None and tempSortBy != '' and tempSortDir is not None and tempSortDir != '' ):
-        if(tempSortBy and tempSortDir):
-            self.urlParam = self.urlParam+"&SortBy="+str(tempSortBy)+"&SortDir="+str(tempSortDir)
-        if(tempTitle): 
-            #tempTitle = set(tempTitle)
-            for each in range(len(tempTitle)):
-                temp = temp + filt + tempTitle[each]
-                #self.urlParam=self.urlParam.join("&title_list="+str(each))
-            
-            #self.urlParam=self.urlParam.join("&title_list="+str(tempTitle))
-            self.urlParam=self.urlParam+temp
-        if(tempYear): 
-            
-            for each in range(len(tempYear)):
-                temp2 = temp2 + filt2 + tempYear[each]
-              
-            self.urlParam=self.urlParam+temp2
-        if(tempMonth): 
-            
-            for each in range(len(tempMonth)):
-                temp3 = temp3 + filt3 + tempMonth[each]
-            self.urlParam=self.urlParam+temp3
-        
-        
+        string = ""
+      
 
-        #urlParam = urlParam+temp
+        self.IndicatorAnchorParam="SortBy=indicator__indicator_title&SortDir=asc"
+        self.YYYYAnchorParam="SortBy=year_month__yyyy&SortDir=desc"
         # Collect GET url parameter info
         temp_sort_dir = self.request.GET.get('SortDir')
         if (temp_sort_dir is not None and temp_sort_dir != '') and (temp_sort_dir == 'asc' or temp_sort_dir == 'desc'):
             self.req_sort_dir = temp_sort_dir
+            
 
         temp_sort_by = self.request.GET.get('SortBy')
         if (temp_sort_by is not None and temp_sort_by != ''):
             self.req_sort_by = temp_sort_by
+           
+        #if(tempSortBy and tempSortDir):
+            #self.urlParam = self.urlParam+"&SortBy="+tempSortBy+"&SortDir="+tempSortDir
+            #self.urlParam = self.urlParam+"&SortBy="+str(tempSortBy)+"&SortDir="+str(tempSortDir)
+
+            #{% if sort_by == 'indicator__indicator_title' and sort_dir == 'asc' %}SortDir=desc{% elif sort_by == 'indicator__indicator_title' and sort_dir == 'desc' %}SortDir=asc{% else %}SortDir=asc{% endif %}
+        if(self.req_sort_by == "indicator__indicator_title" and self.req_sort_dir=="asc"):
+            self.IndicatorAnchorParam="SortBy=indicator__indicator_title&SortDir=desc"
+           
+        elif(self.req_sort_by == "indicator__indicator_title" and self.req_sort_dir=="desc"):
+            self.IndicatorAnchorParam="SortBy=indicator__indicator_title&SortDir=asc"
+           
+        elif(self.req_sort_by == "year_month__yyyy" and self.req_sort_dir=="asc"):
+            self.YYYYAnchorParam="SortBy=year_month__yyyy&SortDir=desc"
+           
+        elif(self.req_sort_by == "year_month__yyyy" and self.req_sort_dir=="desc"):
+            self.YYYYAnchorParam="SortBy=year_month__yyyy&SortDir=asc"
+            
+   
+            
+        for each in range(len(tempTitle)):
+            temp = temp + filt + tempTitle[each]
+              
+        self.urlParam=self.urlParam+temp
+        #if(tempYear): 
+            
+        for each in range(len(tempYear)):
+            temp2 = temp2 + filt2 + tempYear[each]
+              
+        self.urlParam=self.urlParam+temp2
+        #if(tempMonth): 
+            
+        for each in range(len(tempMonth)):
+            temp3 = temp3 + filt3 + tempMonth[each]
+        self.urlParam=self.urlParam+temp3
+        
+        
+
+        self.urlParam = self.urlParam+"&"+self.IndicatorAnchorParam+self.YYYYAnchorParam
+        
 
         # Get list authorized Categories of Indicator Data, and log the category_permissions
         user_cat_permissions = get_user_category_permissions(self.request.user)
@@ -235,6 +260,9 @@ class WebGridPageView(generic.ListView):
             return IndicatorData.objects.none()
 
         # @TODO Filter for only searched indicator title
+
+
+        #refrencee: https://stackoverflow.com/questions/5956391/django-objects-filter-with-list 
         yr_list = self.request.GET.getlist('yr_list')
         if len(yr_list) >= 1:
             #filterStatus = True
@@ -309,13 +337,15 @@ class WebGridPageView(generic.ListView):
         return indicator_data_entries
 
     def get_context_data(self, **kwargs):
-        # Call the base implementation first to get a context
-        
+       
         try:
             context = super().get_context_data(**kwargs)
 
             # Add my own variables to the context for the front end to shows
             context["title_list"] = self.title_list
+            context["IndicatorAnchorParam "]=self.IndicatorAnchorParam 
+            context["YYYYAnchorParam "]=self.YYYYAnchorParam 
+            context["MMAnchorParam "]=self.MMAnchorParam
             context["yr_list"] = self.yr_list
             context["mn_list"] = self.mn_list
             context["urlParam"] = self.urlParam
@@ -332,6 +362,9 @@ class WebGridPageView(generic.ListView):
         except Exception as e:
             self.err_msg = "Exception: get_context_data(): {}".format(e)
             context = super().get_context_data(**kwargs)
+            context["IndicatorAnchorParam "]=self.IndicatorAnchorParam 
+            context["YYYYAnchorParam "]=self.YYYYAnchorParam 
+            context["MMAnchorParam "]=self.MMAnchorParam
             context["uniq_years"] = self.years
             context["mn_list"] = self.mn_list
             context["urlParam"] = self.urlParam

--- a/PMU_DjangoWebApps/PerInd/views.py
+++ b/PMU_DjangoWebApps/PerInd/views.py
@@ -142,6 +142,11 @@ class WebGridPageView(generic.ListView):
     err_msg = ""
     req_sort_dir =  "asc"
     req_sort_by = "indicator__indicator_title"
+    
+    titles=""
+    years=""
+    months=""
+    
   
     def get_queryset(self):
         # Collect GET url parameter info
@@ -169,6 +174,11 @@ class WebGridPageView(generic.ListView):
                 indicator__active=True, # Filters for active Indicator titles
                 year_month__yyyy__gt=timezone.now().year-4, # Filter for only last four year, "yyyy_gt" is "yyyy greater than"
             )
+            #add unique titles to the list
+            self.titles=indicator_data_entries.order_by('indicator__indicator_title').values('indicator__indicator_title').distinct()
+            self.years=indicator_data_entries.order_by('year_month__yyyy').values('year_month__yyyy').distinct()
+            self.months=indicator_data_entries.order_by('year_month__mm').values('year_month__mm').distinct()
+
         except Exception as e:
             self.req_success = False
             self.err_msg = "Exception: WebGridPageView(): get_queryset(): {}".format(e)
@@ -176,6 +186,7 @@ class WebGridPageView(generic.ListView):
             return IndicatorData.objects.none()
 
         # @TODO Filter for only searched indicator title
+
         try:
             if self.req_sort_dir == "asc":
                 indicator_data_entries = indicator_data_entries.order_by(self.req_sort_by)
@@ -202,6 +213,9 @@ class WebGridPageView(generic.ListView):
             context = super().get_context_data(**kwargs)
 
             # Add my own variables to the context for the front end to shows
+            context["uniq_titles"] = self.titles
+            context["uniq_years"] = self.years
+            context["uniq_months"] = self.months
             context["sort_dir"] = self.req_sort_dir
             context["sort_by"] = self.req_sort_by
             context["req_success"] = self.req_success
@@ -210,6 +224,9 @@ class WebGridPageView(generic.ListView):
             return context
         except Exception as e:
             self.err_msg = "Exception: get_context_data(): {}".format(e)
+            context["uniq_years"] = self.years
+            context["uniq_months"] = self.months
+            context["uniq_titles"] = self.titles
             context["sort_dir"] = self.req_sort_dir
             context["sort_by"] = self.req_sort_by
             context["req_success"] = False


### PR DESCRIPTION
Add Title, Year, and Month drop down list to choose what to filer for.

Has two bugs:

    Now there's just two bugs left. First one is when you click on sort by Year, you will get a refresh page. Then you choose an filter, you will see taht the sorting is gone back to Title, where it should stay on sorting by Year. This should be a easy fix, probably just need to edit on what param to send when you click on the submit button in the filter UI

    The 2nd bug being that you cannot cross filter, so you can only filter by year, or by title, or by month, but not together
This probably could be fixed by making sure on each request, we prefill the filter UI with what's in
{{ title_list_filter }}, {{ yr_list_filter }}, and {{ mn_list_filter }}